### PR TITLE
Add default value in new_impl/4 for backward compatibility

### DIFF
--- a/lib/croma/struct.ex
+++ b/lib/croma/struct.ex
@@ -144,7 +144,7 @@ defmodule Croma.Struct do
   end
 
   @doc false
-  def new_impl(mod, struct_fields, dict, recursive?) do
+  def new_impl(mod, struct_fields, dict, recursive? \\ false) do # Default argument for backward compatibility
     rs = Enum.map(struct_fields, fn {field, fields_to_fetch, mod} ->
       case dict_fetch2(dict, fields_to_fetch) do
         {:ok, v} -> evaluate_existing_field(mod, v, recursive?)


### PR DESCRIPTION
To accept call from structs generated with older croma version, add default value in `recursive?` parameter.