### PR TITLE
new/1 for ad-hoc type modules

### DIFF
--- a/test/type_gen_test.exs
+++ b/test/type_gen_test.exs
@@ -58,5 +58,10 @@ defmodule Croma.TypeGenTest do
     assert S.validate(%{"i" => -1, "l" => []}) == {:error, {:invalid_value, [S, nilable(I), I]}}
     assert S.update(s, %{i: -1})               == {:error, {:invalid_value, [S, nilable(I), I]}}
     assert S.update(s, %{l: [-1]})             == {:error, {:invalid_value, [S, I]}}
+
+    assert nilable(S).validate(nil     ) == {:ok, nil}
+    assert nilable(S).validate(%{}     ) == {:error, {:invalid_value, [nilable(S), S, list_of(I)]}}
+    assert nilable(S).validate(%{l: []}) == {:ok, %S{i: nil, l: []}}
+    assert nilable(S).new(%{})           == {:ok, %S{i: nil, l: []}}
   end
 end


### PR DESCRIPTION
As discussed IRL, this PR introduce `new/1` to ad-hoc modules generated by `Croma.TypeGen.nilable/1`and`list_of/1`, leveraging struct generation with `Croma.Struct`.

[Rationale]
Currently, without `new/1` in these modules, struct modules generated by `Croma.Struct` cannot generate struct from maps with `new/1` in some cases, even with `recursive_new?: true` option.
This is because, we sometimes use type modules which cannot "convert" input values on `validate/1`

Dumb example:
```ex
defmodule TaggedInt do
  @type t :: {__MODULE__, integer}

  def validate({__MODULE__, i} = st) when is_integer(i), do: {:ok, st}
  def validate(_), do: {:error, {:invalid_value, [__MODULE__]}}

  def new(str) when is_binary(str) do
    case Integer.parse(str) do
      {i, _} -> {:ok, {__MODULE__, i}}
      :error -> {:error, {:invalid_value, [__MODULE__]}}
    end
  end
  def new(i) when is_integer(i) do
    {:ok, {__MODULE__, i}}
  end
  def new(term) do
    validate(term)
  end
end
```

The above `TaggedInt` is record type which follows Croma type module convention (exports `t` and `validate/1`).
Its `validate/1` only validates input (as it should), but its `new/1` tries to parse input and generate `TaggedInt.t`.

With this type module, we can do this:
```ex
defmodule SomeStruct do
  use Croma.Struct, recursive_new?: true, fields: [ti: TaggedInt]
end

iex> SomeStruct.new(%{"ti" => 1})
{:ok, %SomeStruct{ti: {TaggedInt, 1}}}
```
This is convenient in cases such as converting from JSON into Elixir struct (via JSON deserializer such as `poison`).

Though, we cannot do this with `nilable/1` or `list_of/1`:
```ex
defmodule StructWithNilable do
  use Croma.Struct, recursive_new?: true, fields: [ti: Croma.TypeGen.nilable(TaggedInt)]
end

iex> StructWithNilable.new(%{"ti" => 1})
{:error, {:invalid_value, [StructWithNilable, Croma.TypeGen.Nilable.TaggedInt, TaggedInt]}}
```

This PR tries to solve the above and allow recursively generating values of underlying type module through `nilable/1` or `list_of/1`.