### PR TITLE
Croma depends on :mix application during dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Croma.Mixfile do
   end
 
   def application() do
-    []
+    if Mix.env() == :dev, do: [extra_applications: [:mix]], else: []
   end
 
   defp deps() do


### PR DESCRIPTION
This will fix https://github.com/skirino/croma/issues/15

```console
$ mix dialyzer
Generated croma app
Finding suitable PLTs
Checking PLT...
[:compiler, :elixir, :kernel, :mix, :stdlib]
Looking up modules in dialyxir_erlang-24.3.4.13_elixir-1.13.4_deps-dev.plt
Finding applications for dialyxir_erlang-24.3.4.13_elixir-1.13.4_deps-dev.plt
Finding modules for dialyxir_erlang-24.3.4.13_elixir-1.13.4_deps-dev.plt
Checking 506 modules in dialyxir_erlang-24.3.4.13_elixir-1.13.4_deps-dev.plt
Adding 95 modules to dialyxir_erlang-24.3.4.13_elixir-1.13.4_deps-dev.plt
done in 0m1.98s
No :ignore_warnings opt specified in mix.exs and default does not exist.

Starting Dialyzer
[
  check_plt: false,
  init_plt: '/Users/yukisekiguchi/work/croma/_build/dev/dialyxir_erlang-24.3.4.13_elixir-1.13.4_deps-dev.plt',
  files: ['/Users/yukisekiguchi/work/croma/_build/dev/lib/croma/ebin/Elixir.Croma.TypeGen.ListOf.Croma.PosInteger.beam',
   '/Users/yukisekiguchi/work/croma/_build/dev/lib/croma/ebin/Elixir.Croma.TypeGen.Nilable.Croma.Reference.beam',
   '/Users/yukisekiguchi/work/croma/_build/dev/lib/croma/ebin/Elixir.Croma.Float.beam',
   '/Users/yukisekiguchi/work/croma/_build/dev/lib/croma/ebin/Elixir.Croma.Map.beam',
   '/Users/yukisekiguchi/work/croma/_build/dev/lib/croma/ebin/Elixir.Croma.TypeGen.ListOf.Croma.BitString.beam',
   ...],
  warnings: [:unknown]
]
Total errors: 0, Skipped: 0, Unnecessary Skips: 0
done in 0m0.46s
done (passed successfully)

```